### PR TITLE
Qt: Handles walletmodel BalanceChanged signal/slots for watchonly

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -16,6 +16,7 @@ WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *p
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),
     cachedBalance(0), cachedStake(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
+    cachedWatchBalance(0), cachedWatchStake(0), cachedWatchUnconfirmedBalance(0), cachedWatchImmatureBalance(0),
     cachedEncryptionStatus(Unencrypted),
     cachedNumBlocks(0)
 {
@@ -133,14 +134,24 @@ void WalletModel::checkBalanceChanged()
     qint64 newStake = getStake();
     qint64 newUnconfirmedBalance = getUnconfirmedBalance();
     qint64 newImmatureBalance = getImmatureBalance();
+    qint64 newWatchBalance = getWatchBalance();
+    qint64 newWatchStake = getWatchStake();
+    qint64 newWatchUnconfirmedBalance = getWatchUnconfirmedBalance();
+    qint64 newWatchImmatureBalance = getWatchImmatureBalance();
 
-    if(cachedBalance != newBalance || cachedStake != newStake || cachedUnconfirmedBalance != newUnconfirmedBalance || cachedImmatureBalance != newImmatureBalance)
+    if(cachedBalance != newBalance || cachedStake != newStake || cachedUnconfirmedBalance != newUnconfirmedBalance || cachedImmatureBalance != newImmatureBalance
+            || cachedWatchBalance != newWatchBalance || cachedWatchStake != newWatchStake || cachedWatchUnconfirmedBalance != newWatchUnconfirmedBalance || cachedWatchImmatureBalance != newWatchImmatureBalance )
     {
         cachedBalance = newBalance;
         cachedStake = newStake;
         cachedUnconfirmedBalance = newUnconfirmedBalance;
         cachedImmatureBalance = newImmatureBalance;
-        emit balanceChanged(newBalance, newStake, newUnconfirmedBalance, newImmatureBalance);
+        cachedWatchBalance = newWatchBalance;
+        cachedWatchStake = newWatchStake;
+        cachedWatchUnconfirmedBalance = newWatchUnconfirmedBalance;
+        cachedWatchImmatureBalance = newWatchImmatureBalance;
+        emit balanceChanged(newBalance, newStake, newUnconfirmedBalance, newImmatureBalance,
+                                newWatchBalance, newWatchStake, newWatchUnconfirmedBalance, newWatchImmatureBalance);
     }
 }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -147,6 +147,10 @@ private:
     qint64 cachedStake;
     qint64 cachedUnconfirmedBalance;
     qint64 cachedImmatureBalance;
+    qint64 cachedWatchBalance;
+    qint64 cachedWatchStake;
+    qint64 cachedWatchUnconfirmedBalance;
+    qint64 cachedWatchImmatureBalance;
     EncryptionStatus cachedEncryptionStatus;
     int cachedNumBlocks;
 
@@ -171,7 +175,8 @@ public slots:
 
 signals:
     // Signal that balance in wallet changed
-    void balanceChanged(qint64 balance, qint64 stake, qint64 unconfirmedBalance, qint64 immatureBalance);
+    void balanceChanged(qint64 balance, qint64 stake, qint64 unconfirmedBalance, qint64 immatureBalance,
+                        qint64 watchBalance, qint64 watchStake, qint64 watchUnconfirmedBalance, qint64 watchImmatureBalance);
 
     // Encryption status of wallet changed
     void encryptionStatusChanged(int status);


### PR DESCRIPTION
#### What does this pull request do?
Handles watchonly balances in walletmodel BalanceChanged and CheckBalance. Also fixes signal/slots for watchonly balance member variables.
#### Did you test this pull request?
Yes.
#### Any background context you want to provide?
Watchonly is a new function of the core.  This PR fixes dashboard UI balance updates caused by adding watchonly.
#### Questions:
- Does the readme or documentation need an update? No.
- Does this add new C++ dependencies which need to be added? No.
- Does this change the chain or fork the network? No.

