### PR TITLE
Core: Wallet fixes due to adding watch-only.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -677,8 +677,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
                 }
             }
         }
+        //// debug print
+        LogPrintf("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""));
+
         // since AddToWallet is called directly for self-originating transactions, check for consumption of own coins
         WalletUpdateSpent(wtx, (wtxIn.hashBlock != 0));
+
+        // Break debit/credit balance caches:
+        wtx.MarkDirty();
 
         // Notify UI of new or updated transaction
         NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -593,6 +593,10 @@ public:
         fAvailableCreditCached = false;
         fDebitCached = false;
         fChangeCached = false;
+        fWatchDebitCached = false;
+        fWatchCreditCached = false;
+        fAvailableWatchCreditCached = false;
+        fImmatureWatchCreditCached = false;
     }
 
     void BindWallet(CWallet *pwalletIn)
@@ -651,6 +655,8 @@ public:
                 debit += nDebitCached;
             }
         }
+        //TODO (Amir): Fix issue with watch-only code below. Currently returns the wrong debit value.
+        /*
         if(filter & MINE_WATCH_ONLY)
         {
             if(fWatchDebitCached)
@@ -662,6 +668,7 @@ public:
                 debit += nWatchDebitCached;
             }
         }
+        */
         return debit;
     }
 
@@ -684,6 +691,8 @@ public:
                 credit += nCreditCached;
             }
         }
+        //TODO (Amir): Fix issue with watch-only code below. Currently returns the wrong credit value.
+        /*
         if (filter & MINE_WATCH_ONLY)
         {
             if (fWatchCreditCached)
@@ -695,6 +704,7 @@ public:
                 credit += nWatchCreditCached;
             }
         }
+        */
         return credit;
     }
 


### PR DESCRIPTION
#### What does this pull request do?

1. Fixes incorrect net amount and fee in the UI. 
2. Removes watch-only code in `CWalletTx::GetCredit` and `CWalletTx::GetDebit`.  
3. Adds missing call to `MarkDirty` in `AddToWallet.`

#### Did you test this pull request?
Yes and it fixed the issue above.
#### Any background context you want to provide?
Watch-only is a new core function so issues arose after adding it.
#### Questions:
- Does the readme or documentation need an update? No.
- Does this add new C++ dependencies which need to be added? No.
- Does this change the chain or fork the network? No.

#### Comments/Notes:
The watch-only code still needs work in Silk but we should merge this PR to fix the UI issue.  It is difficult to use when the incorrect net amount shows in the dashboard, transaction table and details.  The missing `MarkDirty` in `AddToWallet.` is also a problem in DarkSilk so we need to remember to add that.