### PR TITLE
[UI] Fixes sync height in peer table while chain downloading.

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -455,7 +455,12 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     if (stats->fNodeStateStatsAvailable) {
         // Ban score is init to 0
         ui->peerBanScore->setText(QString("%1").arg(stats->nodeStateStats.nMisbehavior));
-        ui->peerSyncedBlocks->setText(QString("%1").arg((clientModel->getNumBlocks() - stats->nodeStats.nStartingHeight)));
+        if (stats->nodeStats.nStartingHeight <= clientModel->getNumBlocks()) {
+            ui->peerSyncedBlocks->setText(QString("%1").arg((clientModel->getNumBlocks() - stats->nodeStats.nStartingHeight)));
+        }
+        else {
+             ui->peerSyncedBlocks->setText(QString("Chain downloading"));
+        }
     }
 
     ui->detailWidget->show();


### PR DESCRIPTION
<!--- Remove sections that do not apply -->

#### What is the purpose of this pull request (PR)?
The sync height displayed in the peer table display was an incorrect, negative value, while the wallet is downloading the chain.  This PR fixes this issue #25.

#### Was this PR tested and how (if not, why)?
1. Delete block chain files
2. Launch qt wallet
3. Open peer table view
4. Select peer with fully downloaded chain.  
Now displays "Chain downloading" instead of a negative number.

#### Does this PR resolve an open issue (reference issue #)?
1. Fixes issue #25 

#### More Questions:
- Does the knowledge base need an update? No.
- Does this PR add or change dependencies? No.
- Does this change the chain or fork the network? No.